### PR TITLE
No proptypes in code.

### DIFF
--- a/imports/ui/LeaderBoard.js
+++ b/imports/ui/LeaderBoard.js
@@ -109,6 +109,10 @@ export default class LeaderBoard extends Component {
     );
   }
 }
+
+LeaderBoard.propTypes = {
+  records:PropTypes.array.isRequired,
+};
 /*LeaderBoard.propTypes = {
   records:PropTypes.array.isRequired,
 };


### PR DESCRIPTION
The only code that specifies the incoming prop-types is commented. Must include the prop-types of records.